### PR TITLE
Fix spacing of article sharing links

### DIFF
--- a/website/templates/home/article.html
+++ b/website/templates/home/article.html
@@ -45,18 +45,15 @@
             <div class="container">
                 <div class="columns">
                     <div class="column is-size-3 is-offset-1">
-                        <a href="https://www.facebook.com/sharer/sharer.php?u=
-                                {{ "https://www.minigigscyclingteam.nl" | urlencode }}{{ request.path | urlencode }}"
+                        <a href="https://www.facebook.com/sharer/sharer.php?u={{ "https://www.minigigscyclingteam.nl" | urlencode }}{{ request.path | urlencode }}"
                            target="_blank">
                             <i class="fab fa-facebook"></i>
                         </a>
-                        <a href="https://twitter.com/home?status=
-                                {{ "https://www.minigigscyclingteam.nl" | urlencode }}{{ request.path | urlencode }}"
+                        <a href="https://twitter.com/home?status={{ "https://www.minigigscyclingteam.nl" | urlencode }}{{ request.path | urlencode }}"
                            target="_blank">
                             <i class="fab fa-twitter"></i>
                         </a>
-                        <a href="mailto:info@example.com?&subject=&body=
-                                {{ "https://www.minigigscyclingteam.nl" | urlencode }}{{ request.path | urlencode }}"
+                        <a href="mailto:info@example.com?&subject=&body={{ "https://www.minigigscyclingteam.nl" | urlencode }}{{ request.path | urlencode }}"
                            target="_blank">
                             <i class="fas fa-envelope"></i>
                         </a>


### PR DESCRIPTION
The links to share an article on social media had additional whitespace in them because of an improper auto-formatter run. I've corrected it manually, so the links should now show up without additional whitespace characters.